### PR TITLE
Dft namespace fix

### DIFF
--- a/src/main/scala/com/codecommit/antixml/XMLParser.scala
+++ b/src/main/scala/com/codecommit/antixml/XMLParser.scala
@@ -80,23 +80,9 @@ trait XMLParser {
 
 object XMLParser {
   private [antixml] def selectBinding(prefix: String, uri: String, scopes: NamespaceBinding): NamespaceBinding = {
-    if (prefix.isEmpty) {
-      if (!scopes.findByUri(uri).isDefined) {
-        val parent = scopes.findByPrefix("").map(_.parent).getOrElse(scopes)
-        parent.append(if (uri == null) "" else uri)
-      }
-      else {
-        scopes
-      }
-    }
-    else {
-      if (!scopes.findByUri(uri, prefix).isDefined) {
-        scopes.append(prefix, uri)
-      }
-      else {
-        scopes
-      }
+    scopes.findByPrefix(prefix) match {
+      case Some(ns) if ns.uri == Some(uri) => scopes
+      case _  => if (prefix.isEmpty) NamespaceBinding(uri, scopes) else NamespaceBinding(prefix, uri, scopes) 
     }
   }
-
 }

--- a/src/main/scala/com/codecommit/antixml/namespace.scala
+++ b/src/main/scala/com/codecommit/antixml/namespace.scala
@@ -9,6 +9,7 @@ import annotation.tailrec
  */
 sealed trait NamespaceBinding {
   def uri: Option[String]
+  def prefix: Option[String]
 
   def parent: NamespaceBinding
 
@@ -20,26 +21,28 @@ sealed trait NamespaceBinding {
 
   @tailrec final def findByPrefix(prefix: String): Option[NamespaceBinding] = this match {
     case EmptyNamespaceBinding => None
-    case UnprefixedNamespaceBinding(_, parent) => if(prefix.isEmpty) Some(this) else parent.findByPrefix(prefix)
-    case PrefixedNamespaceBinding(p, _, parent) => if(p == prefix) Some(this) else parent.findByPrefix(prefix)
+    case UnprefixedNamespaceBinding(_, parent) => if (prefix.isEmpty) Some(this) else parent.findByPrefix(prefix)
+    case PrefixedNamespaceBinding(p, _, parent) => if (p == prefix) Some(this) else parent.findByPrefix(prefix)
   }
 
   // If prefix is supplied, then an UnprefixedNamespaceBinding will never be returned
-  @tailrec final def findByUri(uri: String, prefix: String=""): Option[NamespaceBinding] = this match {
+  final def findByUri(uri: String, prefix: String = ""): Option[NamespaceBinding] = {
+    @tailrec def find(nb: NamespaceBinding, checked: Set[String]): Option[NamespaceBinding] = nb match {
       case EmptyNamespaceBinding => None
-      case PrefixedNamespaceBinding(p, u, parent) => if (u == uri && (prefix.isEmpty() || p==prefix)) Some(this) else parent.findByUri(uri, prefix)
-      case UnprefixedNamespaceBinding(u, parent) => if (prefix.isEmpty() && u == uri) Some(this) else parent.findByUri(uri, prefix)
+      case PrefixedNamespaceBinding(p, u, parent) => if (u == uri && (prefix.isEmpty() || p == prefix) && checked.contains(p)) Some(nb) else find(parent, checked + p)
+      case UnprefixedNamespaceBinding(u, parent) => if (prefix.isEmpty() && u == uri && !checked.contains("")) Some(nb) else find(parent, checked + "")
     }
-
-  def findPrefixes(uri: String): List[String] = {
-    @tailrec def find(nb: NamespaceBinding, list: List[String]): List[String] = nb match {
-      case EmptyNamespaceBinding => list
-      case UnprefixedNamespaceBinding(u, parent) => find(parent, if(u == uri) "" :: list else list)
-      case PrefixedNamespaceBinding(p, u, parent) => find(parent, if(u == uri) p :: list else list)
-    }
-    find(this, Nil)
+    find(this, Set.empty)
   }
 
+  def findPrefixes(uri: String): List[String] = {
+    @tailrec def find(nb: NamespaceBinding, checked: Set[String], list: List[String]): List[String] = nb match {
+      case EmptyNamespaceBinding => list
+      case UnprefixedNamespaceBinding(u, parent) => find(parent, checked + "", if (u == uri && !checked.contains("")) "" :: list else list)
+      case PrefixedNamespaceBinding(p, u, parent) => find(parent, checked + p, if (u == uri && !checked.contains(p)) p :: list else list)
+    }
+    find(this, Set.empty, Nil)
+  }
 
   /**
    * This is probably not a good idea.
@@ -47,11 +50,13 @@ sealed trait NamespaceBinding {
   private[antixml] def noParent: NamespaceBinding
 
   def toList: List[NamespaceBinding] = {
-    @tailrec def toList(nb: NamespaceBinding, list: List[NamespaceBinding]): List[NamespaceBinding] = nb match {
-      case EmptyNamespaceBinding => list
-      case binding => toList(binding.parent, binding.noParent :: list)
+    @tailrec def toList(nb: NamespaceBinding, checked: Set[String], list: List[NamespaceBinding]): List[NamespaceBinding] = {
+      if (nb.isEmpty) list else {
+        val pfx = nb.prefix.getOrElse("")
+        toList(nb.parent, checked+pfx, if (checked.contains(pfx)) list else nb.noParent :: list)
+      }
     }
-    toList(this, Nil).reverse
+    toList(this, Set.empty, Nil).reverse
   }
 }
 
@@ -62,9 +67,9 @@ object NamespaceBinding {
 
   def apply(t: (String, String), parent: NamespaceBinding) = new PrefixedNamespaceBinding(t._1, t._2, parent)
 
-  def apply(prefix: String,  uri: String, parent: NamespaceBinding) = new PrefixedNamespaceBinding(prefix, uri, parent)
+  def apply(prefix: String, uri: String, parent: NamespaceBinding) = new PrefixedNamespaceBinding(prefix, uri, parent)
 
-  def apply(prefix: String,  uri: String) = new PrefixedNamespaceBinding(prefix, uri, empty)
+  def apply(prefix: String, uri: String) = new PrefixedNamespaceBinding(prefix, uri, empty)
 
   def apply(uri: String, parent: NamespaceBinding) = new UnprefixedNamespaceBinding(uri, parent)
 
@@ -82,8 +87,9 @@ object NSRepr {
   def apply(nb: NamespaceBinding): NSRepr = new NSRepr(nb.uri.getOrElse(throw new IllegalArgumentException("A namespace binding has to have an URI")))
 }
 
-private [antixml]case object EmptyNamespaceBinding extends NamespaceBinding {
+private[antixml] case object EmptyNamespaceBinding extends NamespaceBinding {
   def uri = None
+  def prefix = None
   def parent = throw new IllegalStateException("No parent for empty")
   def isEmpty = true
 
@@ -92,25 +98,27 @@ private [antixml]case object EmptyNamespaceBinding extends NamespaceBinding {
   override def toList = List.empty
 }
 
-case class PrefixedNamespaceBinding(prefix: String, _uri: String, override val parent: NamespaceBinding = NamespaceBinding.empty) extends NamespaceBinding {
-  if (!Elem.isValidName(prefix)) {
+case class PrefixedNamespaceBinding(_prefix: String, _uri: String, override val parent: NamespaceBinding = NamespaceBinding.empty) extends NamespaceBinding {
+  if (!Elem.isValidName(_prefix)) {
     throw new IllegalArgumentException("Illegal namespace prefix, '" + prefix + "'")
   }
   if (!Elem.isValidNamespaceUri(_uri)) {
     throw new IllegalArgumentException("Illegal namespace uri, '" + _uri + "'")
   }
 
+  def prefix = Some(_prefix)
   def uri = Some(_uri)
   def isEmpty = false
-  private[antixml] def noParent = PrefixedNamespaceBinding(prefix, _uri, NamespaceBinding.empty)
+  private[antixml] def noParent = PrefixedNamespaceBinding(_prefix, _uri, NamespaceBinding.empty)
 }
 
-case class UnprefixedNamespaceBinding(_uri: String,  override val parent: NamespaceBinding = NamespaceBinding.empty) extends NamespaceBinding {
+case class UnprefixedNamespaceBinding(_uri: String, override val parent: NamespaceBinding = NamespaceBinding.empty) extends NamespaceBinding {
   if (!Elem.isValidNamespaceUri(_uri)) {
     throw new IllegalArgumentException("Illegal namespace uri, '" + _uri + "'")
   }
 
   def uri = Some(_uri)
+  def prefix = None
   def isEmpty = false
   private[antixml] def noParent = UnprefixedNamespaceBinding(_uri, NamespaceBinding.empty)
 }

--- a/src/test/scala/com/codecommit/antixml/StAXSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/StAXSpecs.scala
@@ -51,7 +51,7 @@ class StAXSpecs extends Specification {
     }
 
     "parse an element with default namespace prefix and child element with a re-defined default namespace" in {
-      StAXParser.fromString("<a xmlns='urn:a'><b xmlns='urn:b'/></a>") mustEqual Elem(None, "a", Attributes(), NamespaceBinding("urn:a"), Group(Elem(None, "b", Attributes(), NamespaceBinding("urn:b"), Group())))
+      StAXParser.fromString("<a xmlns='urn:a'><b xmlns='urn:b'/></a>") mustEqual Elem(None, "a", Attributes(), NamespaceBinding("urn:a"), Group(Elem(None, "b", Attributes(), NamespaceBinding("urn:b", NamespaceBinding("urn:a")), Group())))
     }
 
     "parse a simpleString and generate an Elem" in {


### PR DESCRIPTION
Fixes the case where:

``` xml
<manifest xmlns="http://www.imsglobal.org/xsd/imscp_v1p1" xmlns:eps="http://eps.pearson.com/xsd/item-metadata">
 <xml xmlns="http://eps.pearson.com/xsd/item-metadata"/>
</manifest>
```

comes out as:

``` xml
<manifest xmlns="http://www.imsglobal.org/xsd/imscp_v1p1" xmlns:eps="http://eps.pearson.com/xsd/item-metadata">
 <xml/>
</manifest>
```

because the non-prefixed namespace matched the uri of an parent prefixed namespace. It should only ignore the namespace if declaration if it matches exactly.
