### PR TITLE
Support lookup and edit of attributes by FQName

### DIFF
--- a/src/main/scala/com/codecommit/antixml/LowPrioritiyImplicits.scala
+++ b/src/main/scala/com/codecommit/antixml/LowPrioritiyImplicits.scala
@@ -23,7 +23,7 @@ trait LowPrioritiyImplicits {
 
     implicit def stringToNsRepr(s: String) = NSRepr(s)
 
-    implicit def namespaceBindingToNsRepr(nb: NamespaceBinding) = NSRepr(nb)
+    implicit def namespaceBindingToNsRepr(nb: NamespaceEntry) = NSRepr(nb)
 
     /**
      * Wildcard selector which passes ''all'' nodes unmodified.  This is analogous

--- a/src/main/scala/com/codecommit/antixml/Selector.scala
+++ b/src/main/scala/com/codecommit/antixml/Selector.scala
@@ -58,7 +58,7 @@ object Selector {
       def canMatchIn(group: Group[Node]) = group.matches(hash)
     }
 
-  implicit def namespaceBindingToSelector(nb: NamespaceBinding): Selector[Elem] =
+  implicit def namespaceBindingToSelector(nb: NamespaceEntry): Selector[Elem] =
     new OptimizingSelector[Elem] {
       private val pf: PartialFunction[Node, Elem] = {
         case e @ ElemNamespaceUri(uri) if nb.uri.filter(uri == _).isDefined => e

--- a/src/test/scala/com/codecommit/antixml/NamespaceSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/NamespaceSpecs.scala
@@ -3,8 +3,8 @@ package com.codecommit.antixml
 import org.specs2.mutable._
 
 class NamespaceSpecs extends Specification {
-  val urnA = NamespaceBinding("urn:a")
-  val urnB = NamespaceBinding("urn:b")
+  val urnA = NamespaceEntry("urn:a")
+  val urnB = NamespaceEntry("urn:b")
 
   "findByUri" should {
     "find None on empty" in {
@@ -12,15 +12,16 @@ class NamespaceSpecs extends Specification {
     }
 
     "find Some('urn:a') from 'urn:a'" in {
-      urnA.findByUri("urn:a") must beSome(urnA)
+      NamespaceBinding(urnA).findByUri("urn:a") must beSome(urnA)
     }
 
-    "find Some('urn:a') from 'urn:a' :: 'urn:b'" in {
-      NamespaceBinding("urn:b", urnA).findByUri("urn:a") must beSome(urnA)
+    // Should be hidden if a more recent ns with same prefix is found
+    "find None from 'urn:a' :: 'urn:b'" in {
+      NamespaceBinding("urn:b", NamespaceBinding(urnA)).findByUri("urn:a") must beNone
     }
 
     "find None from NamespaceBinding('urn:a')" in {
-      urnA.findByUri("urn:b") must beNone
+      NamespaceBinding(urnA).findByUri("urn:b") must beNone
     }
   }
 }

--- a/src/test/scala/com/codecommit/antixml/NodeSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/NodeSpecs.scala
@@ -122,18 +122,18 @@ class NodeSpecs extends Specification with DataTables with ScalaCheck with XMLGe
     "add namespace conveniently" in {
       val elem = Elem(None, "foo", Attributes(), NamespaceBinding("urn:foo:bar"), Group(Text("Somewhat crazy")))
       val withChildren = elem.addNamespace("bar", "urn:foo:baz")
-      withChildren.namespaces.toList must beEqualTo(List(NamespaceBinding("bar", "urn:foo:baz"), NamespaceBinding("urn:foo:bar")))
+      withChildren.namespaces.toList must beEqualTo(List(NamespaceEntry("bar", "urn:foo:baz"), NamespaceEntry("urn:foo:bar")))
     }
 
     "generate namespace" in {
       val elem = Elem(None, "foo", Attributes(), NamespaceBinding("urn:foo:bar"), Group(Text("Somewhat crazy")))
       val withChildren = elem.addNamespace("", "urn:foo:baz")
-      withChildren.namespaces.toList must beEqualTo(List(NamespaceBinding("ns1", "urn:foo:baz"), NamespaceBinding("urn:foo:bar")))
+      withChildren.namespaces.toList must beEqualTo(List(NamespaceEntry("ns1", "urn:foo:baz"), NamespaceEntry("urn:foo:bar")))
     }
 
     "detect illegal attribute prefixes" in check { str: String =>
       name unapplySeq str match {
-        case Some(_) => Elem(None, "foo", Attributes(QName(str, "bar") -> "bar"), PrefixedNamespaceBinding(str, "urn:bar"), Group()) must not(throwAn[IllegalArgumentException])
+        case Some(_) => Elem(None, "foo", Attributes(QName(str, "bar") -> "bar"), NamespaceBinding(str, "urn:bar"), Group()) must not(throwAn[IllegalArgumentException])
         case None => Elem(None, "foo", Attributes(QName(str, "bar") -> "bar"), NamespaceBinding.empty, Group()) must throwAn[IllegalArgumentException]
       }
     }


### PR DESCRIPTION
Support for the lookup of an attribute by full qualified name (uri, localpart). It is not the most efficient because the attribute map should really use a FQName map instead of having to deal with QName's.
